### PR TITLE
Adds support to subclass an Ruby::Enum 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 0.6.1 (Next)
 
-* Your contribution here.
+* [#3](https://github.com/dblock/ruby-enum/pull/13): Adds support for sub classing an Enum - [@laertispappas](https://github.com/laertispappas).
+
+-* Your contribution here.
 
 ### 0.6.0 (12/5/2016)
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'rspec', '~> 3.4.0'
-gem 'rake'
+gem 'rake', '< 11.0'
 gem 'rubocop', '0.35.1'

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Colors.key('yellow')
 ```
 
 
-## Duplicate enumerator keys or duplicate values
+### Duplicate enumerator keys or duplicate values
 
 Defining duplicate enums will raise a `Ruby::Enum::Errors::DuplicateKeyError`. Moreover a duplicate
-value is not allowed. Defining a duplicate value will raise a `Ruby::Enum::Errors::DuplicateKeyError`.
+value is not allowed. Defining a duplicate value will raise a `Ruby::Enum::Errors::DuplicateValueError`.
 The following declarations will both raise an exception:
 
 ```ruby
@@ -136,7 +136,7 @@ The following declarations will both raise an exception:
   end
 
   # The following will raise a DuplicateValueError
-  class Colots
+  class Colors
     include Ruby::Enum
 
     define :RED, 'red'
@@ -145,7 +145,7 @@ The following declarations will both raise an exception:
 ```
 
 The `DuplicateValueError` exception is thrown to be consistent with the unique key constraint.
-Since keys are unique there is no way to map values to keys using `Colors.key('red')`
+Since keys are unique there is no way to map values to keys using `Colors.value('red')`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ The following declarations will both raise an exception:
 The `DuplicateValueError` exception is thrown to be consistent with the unique key constraint.
 Since keys are unique there is no way to map values to keys using `Colors.value('red')`
 
+### Inheritance behavior
+
+Inheriting from a `Ruby::Enum` class, all defined enums in the parent class will be accessible in sub classes as well.
+Sub classes can also provide extra enums as usual.
+
 ## Contributing
 
 You're encouraged to contribute to this gem. See [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -45,7 +45,8 @@ module Ruby
       end
 
       def const_missing(key)
-        if @_enum_hash[key]
+        enum_instance = @_enum_hash[key] if @_enum_hash
+        if enum_instance
           @_enum_hash[key].value
         elsif superclass.instance_variable_get(:@_enum_hash)
           superclass.send(:const_missing, key)

--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -10,6 +10,8 @@ module Ruby
     def self.included(base)
       base.extend Enumerable
       base.extend ClassMethods
+
+      base.private_class_method(:new)
     end
 
     module ClassMethods
@@ -45,6 +47,8 @@ module Ruby
       def const_missing(key)
         if @_enum_hash[key]
           @_enum_hash[key].value
+        elsif superclass.instance_variable_get(:@_enum_hash)
+          superclass.send(:const_missing, key)
         else
           fail Ruby::Enum::Errors::UninitializedConstantError, name: name, key: key
         end

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -7,7 +7,38 @@ class Colors
   define :GREEN, 'green'
 end
 
+class FirstSubclass < Colors
+  define :ORANGE, 'orange'
+end
+
+class SecondSubclass < FirstSubclass
+  define :PINK, 'pink'
+end
+
 describe Ruby::Enum do
+  describe 'Subclass behavior' do
+    it 'contains the enums defined in the parent class' do
+      expect(FirstSubclass::GREEN).to eq 'green'
+      expect(FirstSubclass::RED).to eq 'red'
+    end
+
+    it 'contains its own enums' do
+      expect(FirstSubclass::ORANGE).to eq 'orange'
+    end
+    it 'parent class should not have enums defined in child classes' do
+      expect { Colors::ORANGE }.to raise_error Ruby::Enum::Errors::UninitializedConstantError
+    end
+    context 'Given a 2 level depth subclass' do
+      subject { SecondSubclass }
+      it 'contains its own enums and all the enums defined in the parent classes' do
+        expect(subject::RED).to eq 'red'
+        expect(subject::GREEN).to eq 'green'
+        expect(subject::ORANGE).to eq 'orange'
+        expect(subject::PINK).to eq 'pink'
+      end
+    end
+  end
+
   it 'returns an enum value' do
     expect(Colors::RED).to eq 'red'
     expect(Colors::GREEN).to eq 'green'

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -160,4 +160,13 @@ describe Ruby::Enum do
       end.to raise_error Ruby::Enum::Errors::DuplicateValueError, /The value red has already been defined./
     end
   end
+
+  describe 'Given a class that has not defined any enums' do
+    class EmptyEnums
+      include Ruby::Enum
+    end
+    it do
+      expect { EmptyEnums::ORANGE }.to raise_error Ruby::Enum::Errors::UninitializedConstantError
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses the feature described in #3. Ruby::Enum now supports subclassing by inheriting all enums defined in the parent class. New enums may be defined in subclasses of course. I also made fixed some typos in the README and fixed the code to raise the correct exception when a Ruby::Enum class has not defined any enums (empty class ).  