### PR TITLE
Remove const_missing method in favor of const_set

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,6 +17,9 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 148
 
+Metrics/BlockLength:
+    ExcludedMethods: ['describe', 'context']
+
 # Offense count: 4
 Style/Documentation:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 0.7.1 (Next)
 
+* [#16](https://github.com/dblock/ruby-enum/pull/16): Replaces const_missing method in favor of const_set - [@laertispappas](https://github.com/laertispappas).
+
 * Your contribution here.
 
 ### 0.7.0 (21/2/2017)

--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -30,6 +30,8 @@ module Ruby
         new_instance = new(key, value)
         @_enum_hash[key] = new_instance
         @_enums_by_value[value] = new_instance
+
+        const_set key, value
       end
 
       def validate_key!(key)
@@ -45,14 +47,7 @@ module Ruby
       end
 
       def const_missing(key)
-        enum_instance = @_enum_hash && @_enum_hash[key]
-        if enum_instance
-          @_enum_hash[key].value
-        elsif superclass.instance_variable_get(:@_enum_hash)
-          superclass.send(:const_missing, key)
-        else
-          raise Ruby::Enum::Errors::UninitializedConstantError, name: name, key: key
-        end
+        raise Ruby::Enum::Errors::UninitializedConstantError, name: name, key: key
       end
 
       # Iterate over all enumerated values.

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -169,4 +169,12 @@ describe Ruby::Enum do
       expect { EmptyEnums::ORANGE }.to raise_error Ruby::Enum::Errors::UninitializedConstantError
     end
   end
+
+  context 'when a constant is redefined in a global namespace' do
+    before do
+      RED = 'black'.freeze
+    end
+
+    it { expect(Colors::RED).to eq 'red' }
+  end
 end


### PR DESCRIPTION
Define constant with const_set instead of "fetching"
them with const_missing. These changes were proposed
by @dmoss18 in his initial PR (https://github.com/dblock/ruby-enum/pull/11).

I kept const_missing method in order to raise the custom
Ruby::Enum::Errors::DuplicateKeyError since
it provides a handy way to inform the end user
for the exception raised.