### PR TITLE
Adds support for non constant definitions

### DIFF
--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -27,23 +27,19 @@ module Ruby
         validate_key!(key)
         validate_value!(value)
 
+        store_new_instance(key, value)
+
+        if upper?(key.to_s)
+          const_set key, value
+        else
+          define_singleton_method(key) { value }
+        end
+      end
+
+      def store_new_instance(key, value)
         new_instance = new(key, value)
         @_enum_hash[key] = new_instance
         @_enums_by_value[value] = new_instance
-
-        const_set key, value
-      end
-
-      def validate_key!(key)
-        return unless @_enum_hash.key?(key)
-
-        raise Ruby::Enum::Errors::DuplicateKeyError, name: name, key: key
-      end
-
-      def validate_value!(value)
-        return unless @_enums_by_value.key?(value)
-
-        raise Ruby::Enum::Errors::DuplicateValueError, name: name, value: value
       end
 
       def const_missing(key)
@@ -127,6 +123,24 @@ module Ruby
         Hash[@_enum_hash.map do |key, enum|
           [key, enum.value]
         end]
+      end
+
+      private
+
+      def upper?(s)
+        !/[[:upper:]]/.match(s).nil?
+      end
+
+      def validate_key!(key)
+        return unless @_enum_hash.key?(key)
+
+        raise Ruby::Enum::Errors::DuplicateKeyError, name: name, key: key
+      end
+
+      def validate_value!(value)
+        return unless @_enums_by_value.key?(value)
+
+        raise Ruby::Enum::Errors::DuplicateValueError, name: name, value: value
       end
     end
   end

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -16,29 +16,6 @@ class SecondSubclass < FirstSubclass
 end
 
 describe Ruby::Enum do
-  describe 'Subclass behavior' do
-    it 'contains the enums defined in the parent class' do
-      expect(FirstSubclass::GREEN).to eq 'green'
-      expect(FirstSubclass::RED).to eq 'red'
-    end
-
-    it 'contains its own enums' do
-      expect(FirstSubclass::ORANGE).to eq 'orange'
-    end
-    it 'parent class should not have enums defined in child classes' do
-      expect { Colors::ORANGE }.to raise_error Ruby::Enum::Errors::UninitializedConstantError
-    end
-    context 'Given a 2 level depth subclass' do
-      subject { SecondSubclass }
-      it 'contains its own enums and all the enums defined in the parent classes' do
-        expect(subject::RED).to eq 'red'
-        expect(subject::GREEN).to eq 'green'
-        expect(subject::ORANGE).to eq 'orange'
-        expect(subject::PINK).to eq 'pink'
-      end
-    end
-  end
-
   it 'returns an enum value' do
     expect(Colors::RED).to eq 'red'
     expect(Colors::GREEN).to eq 'green'
@@ -176,5 +153,47 @@ describe Ruby::Enum do
     end
 
     it { expect(Colors::RED).to eq 'red' }
+  end
+
+  describe 'Subclass behavior' do
+    it 'contains the enums defined in the parent class' do
+      expect(FirstSubclass::GREEN).to eq 'green'
+      expect(FirstSubclass::RED).to eq 'red'
+    end
+
+    it 'contains its own enums' do
+      expect(FirstSubclass::ORANGE).to eq 'orange'
+    end
+    it 'parent class should not have enums defined in child classes' do
+      expect { Colors::ORANGE }.to raise_error Ruby::Enum::Errors::UninitializedConstantError
+    end
+    context 'Given a 2 level depth subclass' do
+      subject { SecondSubclass }
+      it 'contains its own enums and all the enums defined in the parent classes' do
+        expect(subject::RED).to eq 'red'
+        expect(subject::GREEN).to eq 'green'
+        expect(subject::ORANGE).to eq 'orange'
+        expect(subject::PINK).to eq 'pink'
+      end
+    end
+  end
+
+  describe 'non constant definitions' do
+    class States
+      include Ruby::Enum
+      define :created, 'Created'
+      define :published, 'Published'
+    end
+    subject { States }
+    it 'behaves like an enum' do
+      expect(subject.created).to eq 'Created'
+      expect(subject.published).to eq 'Published'
+
+      expect(subject.key?(:created)).to be true
+      expect(subject.key('Created')).to eq :created
+
+      expect(subject.value?('Created')).to be true
+      expect(subject.value(:created)).to eq 'Created'
+    end
   end
 end


### PR DESCRIPTION
Addresses issue #17 and adds support for non constant definitions. Although there is no example in the docs where we define enums in lowercase some are using `Ruby::Enum` as follows:

```ruby
class State
  include Ruby::Enum

  define :created, 'Created'
end
````