### PR TITLE
value: default to key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,10 @@ AllCops:
   Exclude:
     - vendor/**/*
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,7 @@
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 180
+  Max: 200
 
 # Offense count: 1
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,12 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Configuration parameters: CountComments, ExcludedMethods.
-# ExcludedMethods: refine
-Metrics/BlockLength:
-  Max: 200
-
-# Offense count: 1
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
 Naming/FileName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#30](https://github.com/dblock/ruby-enum/pull/30): Default value to key - [@gi](https://github.com/gi).
 
 ### 0.8.0 (2020/3/27)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ OrderState.values # ["Created", "Paid"]
 OrderState.to_h # { :created => 'Created', :paid => 'Paid' }
 ```
 
+### Default Value
+
+The value is optional. If unspecified, the value will default to the key.
+
+``` ruby
+class Defaults
+  include Ruby::Enum
+
+  define :UNSPECIFIED
+  define :unspecified
+end
+```
+
+``` ruby
+Defaults::UNSPECIFIED # :UNSPECIFIED
+Defaults.unspecified # :unspecified
+```
+
 ### Enumerating
 
 All `Enumerable` methods are supported.

--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -22,7 +22,7 @@ module Ruby
       # === Parameters
       # [key] Enumerator key.
       # [value] Enumerator value.
-      def define(key, value)
+      def define(key, value = key)
         @_enum_hash ||= {}
         @_enums_by_value ||= {}
 

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -190,6 +190,19 @@ describe Ruby::Enum do
     end
   end
 
+  describe 'default value' do
+    class Default
+      include Ruby::Enum
+      define :KEY
+    end
+
+    subject { Default::KEY }
+
+    it 'equals the key' do
+      expect(subject).to eq(:KEY)
+    end
+  end
+
   describe 'non constant definitions' do
     class States
       include Ruby::Enum

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -208,17 +208,25 @@ describe Ruby::Enum do
       include Ruby::Enum
       define :created, 'Created'
       define :published, 'Published'
+      define :undefined
     end
     subject { States }
     it 'behaves like an enum' do
       expect(subject.created).to eq 'Created'
       expect(subject.published).to eq 'Published'
+      expect(subject.undefined).to eq :undefined
 
       expect(subject.key?(:created)).to be true
       expect(subject.key('Created')).to eq :created
 
       expect(subject.value?('Created')).to be true
       expect(subject.value(:created)).to eq 'Created'
+
+      expect(subject.key?(:undefined)).to be true
+      expect(subject.key(:undefined)).to eq :undefined
+
+      expect(subject.value?(:undefined)).to be true
+      expect(subject.value(:undefined)).to eq :undefined
     end
   end
 end


### PR DESCRIPTION
When defining a new enum, the value is optional. If not specified, the value
defaults to the key.

Fixes #28

```ruby
class A
  include Ruby::Enum
  define :X
end

A::X == :X
```