### PR TITLE
Add `ruby >= 2.3` constraint to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.9.1 (Next)
 
+* [#38](https://github.com/dblock/ruby-enum/pull/38): Ensure Ruby >= 2.3 - [@ojab](https://github.com/ojab).
 * Your contribution here.
 
 ### 0.9.0 (2021/01/21)

--- a/ruby-enum.gemspec
+++ b/ruby-enum.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email = 'dblock@dblock.org'
   s.platform = Gem::Platform::RUBY
   s.required_rubygems_version = '>= 1.3.6'
+  s.required_ruby_version = '>= 2.3'
   s.files = Dir['**/*']
   s.require_paths = ['lib']
   s.homepage = 'http://github.com/dblock/ruby-enum'


### PR DESCRIPTION
Safe navigation is not available earlier and used in the code.