### PR TITLE
Update Ruby version in CI coverage job from 2.7 to 3.2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,17 +6,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install Ruby (2.7)
+    - name: Install Ruby (3.2)
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.2
     - uses: amancevice/setup-code-climate@v0
       with:
         cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
     - run: cc-test-reporter before-build
     - name: Build and test with RSpec
       run: |
-        gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rspec
     - run: cc-test-reporter after-build


### PR DESCRIPTION
Fixes https://github.com/dblock/ruby-enum/issues/44