### PR TITLE
Add Subclass Tests

### DIFF
--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -158,6 +158,18 @@ describe Ruby::Enum do
     it 'returns values' do
       expect(Colors.values).to eq(%w[red green])
     end
+
+    context 'when a subclass is defined' do
+      it 'returns all values' do
+        expect(FirstSubclass.values).to eq(%w[red green orange])
+      end
+    end
+
+    context 'when a subclass of a subclass is defined' do
+      it 'returns all values' do
+        expect(SecondSubclass.values).to eq(%w[red green orange pink])
+      end
+    end
   end
 
   describe '#to_h' do


### PR DESCRIPTION
In my project, I came across an [issue](https://github.com/dblock/ruby-enum/issues/49) that I cannot reproduce in the tests, so it must be a difference in the way I load the rails project code, or perhaps in the switch to Zeitwerk loader. None-the-less, here are two tests that show superclass handling is working correctly for values.

I could not reproduce on the latest version of ruby (`3.3.4` at the time of this PR)