### PR TITLE
Class reloading

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Metrics/BlockLength:
 RSpec/SpecFilePathFormat:
   Enabled: false
 
-Style/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Style/HashEachMethods:
@@ -36,6 +36,9 @@ RSpec/NestedGroups:
   Enabled: false
 
 RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/DescribedClass:
   Enabled: false
 
 RSpec/MultipleExpectations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.1.0 (Next)
 
+* [#56](https://github.com/dblock/ruby-enum/pull/56): Fix `DuplicateKeyError` when the enum class is reloaded - [@flvrone](https://github.com/flvrone).
 * [#54](https://github.com/dblock/ruby-enum/pull/54): Add support for Ruby 4.0 - [@dblock](https://github.com/dblock).
 * [#53](https://github.com/dblock/ruby-enum/pull/53): Replace code climate with coveralls - [@dblock](https://github.com/dblock).
 * Your contribution here.

--- a/lib/ruby-enum/enum.rb
+++ b/lib/ruby-enum/enum.rb
@@ -19,6 +19,9 @@ module Ruby
       base.extend ClassMethods
 
       base.private_class_method(:new)
+
+      base.instance_variable_set(:@_enum_hash, {})
+      base.instance_variable_set(:@_enums_by_value, {})
     end
 
     module ClassMethods

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -242,13 +242,12 @@ describe Ruby::Enum do
     end
   end
 
-  # rubocop:disable Rspec/DescribedClass
   describe 'Reloading enum definition' do
-    it 'plays nice with lazy loading in Ruby on Rails' do
+    it 'can be lazy reloaded' do
       class_body = proc do
         include Ruby::Enum
 
-        define :BALD, 'bald'
+        define :BUZZ_CUT, 'buzz_cut'
       end
 
       HairStyles = Class.new(&class_body)
@@ -256,7 +255,6 @@ describe Ruby::Enum do
       expect { HairStyles.class_eval(&class_body) }.not_to raise_error
     end
   end
-  # rubocop:enable Rspec/DescribedClass
 
   describe 'Given a class that has not defined any enums' do
     class EmptyEnums

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -250,9 +250,36 @@ describe Ruby::Enum do
         define :BUZZ_CUT, 'buzz_cut'
       end
 
-      HairStyles = Class.new(&class_body)
+      hair_styles = Class.new(&class_body)
 
-      expect { HairStyles.class_eval(&class_body) }.not_to raise_error
+      expect { hair_styles.class_eval(&class_body) }.not_to raise_error
+    end
+
+    context 'when a subclass is defined' do
+      it 'NEEDS to include Ruby::Enum explicitly to be lazy reloaded' do
+        hair_styles = Class.new do
+          include Ruby::Enum
+
+          define :BUZZ_CUT, 'buzz_cut'
+        end
+
+        broken_subclass_body = proc do
+          define :PONYTAIL, 'ponytail'
+        end
+        broken_subclass = Class.new(hair_styles, &broken_subclass_body)
+        expect { broken_subclass.class_eval(&broken_subclass_body) }
+          .to raise_error Ruby::Enum::Errors::DuplicateKeyError, /PONYTAIL/
+
+        subclass_body = proc do
+          include Ruby::Enum
+
+          define :PONYTAIL, 'ponytail'
+        end
+        more_hair_styles = Class.new(hair_styles, &subclass_body)
+
+        expect { more_hair_styles.class_eval(&subclass_body) }.not_to raise_error
+        expect(more_hair_styles.values).to eq(%w[buzz_cut ponytail])
+      end
     end
   end
 

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -17,6 +17,13 @@ describe Ruby::Enum do
   class SecondSubclass < FirstSubclass
     define :PINK, 'pink'
   end
+
+  class OtherSecondSubclass < FirstSubclass
+    include Ruby::Enum
+
+    define :MAGENTA, 'magenta'
+  end
+
   it 'returns an enum value' do
     expect(Colors::RED).to eq 'red'
     expect(Colors::GREEN).to eq 'green'
@@ -167,6 +174,12 @@ describe Ruby::Enum do
     context 'when a subclass of a subclass is defined' do
       it 'returns all values' do
         expect(SecondSubclass.values).to eq(%w[red green orange pink])
+      end
+    end
+
+    context 'when a subclass of a subclass is defined with redundant module inclusion' do
+      it 'returns all values' do
+        expect(OtherSecondSubclass.values).to eq(%w[red green orange magenta])
       end
     end
   end

--- a/spec/ruby-enum/enum_spec.rb
+++ b/spec/ruby-enum/enum_spec.rb
@@ -229,6 +229,22 @@ describe Ruby::Enum do
     end
   end
 
+  # rubocop:disable Rspec/DescribedClass
+  describe 'Reloading enum definition' do
+    it 'plays nice with lazy loading in Ruby on Rails' do
+      class_body = proc do
+        include Ruby::Enum
+
+        define :BALD, 'bald'
+      end
+
+      HairStyles = Class.new(&class_body)
+
+      expect { HairStyles.class_eval(&class_body) }.not_to raise_error
+    end
+  end
+  # rubocop:enable Rspec/DescribedClass
+
   describe 'Given a class that has not defined any enums' do
     class EmptyEnums
       include Ruby::Enum


### PR DESCRIPTION
Sometimes when accessing enum classes from rails console - `DuplicateKeyError` is raised, because the class was already loaded (evaluated), but then for whatever reason it tried to load again (evaluate the whole body again), and the previous definitions are still in those instance variables, so it breaks.

Now upon including the module - the instance variable is cleared, and it does not break inheritance. (This issue #49 was already solved and tested, and my PR does not break it).